### PR TITLE
MIT License

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,10 @@
+MIT License
+
+Copyright (c) 2023 Larry Le
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/src/App.js
+++ b/src/App.js
@@ -159,7 +159,7 @@ function App() {
         </ul>
       </div>
 
-      <p className="footer-copyright">©2023 Larry Le All Rights Reserved</p>
+      <p className="footer-copyright">©2023 Larry Le MIT License</p>
     </footer>
   </div>  
   );


### PR DESCRIPTION
The MIT License gives permission for people who obtain the software of the website to use it however they want as long as it doesn't get the school into legal trouble.